### PR TITLE
167 participants screen

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ExternalAPIModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ExternalAPIModule.java
@@ -24,6 +24,9 @@ import com.facebook.react.module.annotations.ReactModule;
 
 import org.jitsi.meet.sdk.log.JitsiMeetLogger;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Module implementing an API for sending events from JavaScript to native code.
  */
@@ -34,6 +37,8 @@ class ExternalAPIModule
     public static final String NAME = "ExternalAPI";
 
     private static final String TAG = NAME;
+
+    public static final String DISPATCH_REDUX_ACTION = "DISPATCH_REDUX_ACTION";
 
     /**
      * Initializes a new module instance. There shall be a single instance of
@@ -54,6 +59,13 @@ class ExternalAPIModule
     @Override
     public String getName() {
         return NAME;
+    }
+
+    @Override
+    public Map<String, Object> getConstants() {
+        Map<String, Object> constants = new HashMap<>();
+        constants.put(DISPATCH_REDUX_ACTION, DISPATCH_REDUX_ACTION);
+        return constants;
     }
 
     /**

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeet.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeet.java
@@ -21,9 +21,14 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
 
 import org.devio.rn.splashscreen.SplashScreen;
 import org.jitsi.meet.sdk.log.JitsiMeetLogger;
+
+import androidx.annotation.Nullable;
 
 public class JitsiMeet {
 
@@ -65,6 +70,10 @@ public class JitsiMeet {
         }
 
         return new Bundle();
+    }
+
+    public static void dispatchReduxAction(Object action) {
+        ReactInstanceManagerHolder.emitEvent(ExternalAPIModule.DISPATCH_REDUX_ACTION, action);
     }
 
     /**

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -237,4 +237,9 @@ public class JitsiMeetActivity extends FragmentActivity
     public void onOpenParticipants(Map<String, Object> data) {
 
     }
+
+    @Override
+    public void onParticipantsChanged(Map<String, Object> data) {
+
+    }
 }

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetViewListener.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetViewListener.java
@@ -61,4 +61,11 @@ public interface JitsiMeetViewListener {
      * @param data is empty.
      */
     void onOpenParticipants(Map<String, Object> data);
+
+    /**
+     * Fired when there is any update in the participants list.
+     *
+     * @param data with "participants" array containing the updated list.
+     */
+    void onParticipantsChanged(Map<String, Object> data);
 }

--- a/ios/sdk/sdk.xcodeproj/project.pbxproj
+++ b/ios/sdk/sdk.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		75635B0820751D6D00F29C9F /* joined.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = joined.wav; path = ../../sounds/joined.wav; sourceTree = "<group>"; };
 		75635B0920751D6D00F29C9F /* left.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = left.wav; path = ../../sounds/left.wav; sourceTree = "<group>"; };
 		87FE6F3221E52437004A5DC7 /* incomingMessage.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = incomingMessage.wav; path = ../../sounds/incomingMessage.wav; sourceTree = "<group>"; };
+		92CF9DF425822695005EF2FF /* ExternalAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExternalAPI.h; sourceTree = "<group>"; };
 		98E09B5C73D9036B4ED252FC /* Pods-JitsiMeet.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JitsiMeet.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-JitsiMeet/Pods-JitsiMeet.debug.xcconfig"; sourceTree = "<group>"; };
 		9C77CA3CC919B081F1A52982 /* Pods-JitsiMeet.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JitsiMeet.release.xcconfig"; path = "../Pods/Target Support Files/Pods-JitsiMeet/Pods-JitsiMeet.release.xcconfig"; sourceTree = "<group>"; };
 		A4414ADF20B37F1A003546E6 /* rejected.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = rejected.wav; path = ../../sounds/rejected.wav; sourceTree = "<group>"; };
@@ -196,6 +197,7 @@
 				0BCA495C1EC4B6C600B793EE /* AudioMode.m */,
 				C69EFA02209A0EFD0027712B /* callkit */,
 				A4A934E7212F3AB8001E9388 /* dropbox */,
+				92CF9DF425822695005EF2FF /* ExternalAPI.h */,
 				0BA13D301EE83FF8007BEF7F /* ExternalAPI.m */,
 				0BD906E91EC0C00300C8C18E /* Info.plist */,
 				DE438CD82350934700DD541D /* JavaScriptSandbox.m */,

--- a/ios/sdk/src/ExternalAPI.h
+++ b/ios/sdk/src/ExternalAPI.h
@@ -1,0 +1,7 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+static NSString * const DISPATCH_REDUX_ACTION = @"DISPATCH_REDUX_ACTION";
+
+@interface ExternalAPI : RCTEventEmitter<RCTBridgeModule>
+@end

--- a/ios/sdk/src/ExternalAPI.m
+++ b/ios/sdk/src/ExternalAPI.m
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-#import <React/RCTBridgeModule.h>
-
 #import "JitsiMeetView+Private.h"
-
-@interface ExternalAPI : NSObject<RCTBridgeModule>
-@end
+#import "ExternalAPI.h"
 
 @implementation ExternalAPI
 
@@ -31,6 +27,12 @@ RCT_EXPORT_MODULE();
 - (dispatch_queue_t)methodQueue {
     return dispatch_get_main_queue();
 }
+
+- (NSDictionary *)constantsToExport {
+    return @{
+        @"DISPATCH_REDUX_ACTION": DISPATCH_REDUX_ACTION
+    };
+};
 
 /**
  * Dispatches an event that occurred on JavaScript to the view's delegate.

--- a/ios/sdk/src/JitsiMeet.h
+++ b/ios/sdk/src/JitsiMeet.h
@@ -69,4 +69,6 @@
 
 - (void)showSplashScreen:(UIView * _Nonnull) rootView;
 
+- (void)dispatchReduxAction:(NSDictionary *)data;
+
 @end

--- a/ios/sdk/src/JitsiMeet.m
+++ b/ios/sdk/src/JitsiMeet.m
@@ -23,6 +23,7 @@
 #import "RCTBridgeWrapper.h"
 #import "ReactUtils.h"
 #import "RNSplashScreen.h"
+#import "ExternalAPI.h"
 
 #import <RNGoogleSignin/RNGoogleSignin.h>
 #import <WebRTC/RTCLogging.h>
@@ -186,6 +187,10 @@
 
 - (void)showSplashScreen:(UIView*)rootView {
     [RNSplashScreen showSplash:@"LaunchScreen" inRootView:rootView];
+}
+
+- (void)dispatchReduxAction:(NSDictionary *)data {
+    [[[self getReactBridge] moduleForClass:[ExternalAPI class]] sendEventWithName:DISPATCH_REDUX_ACTION body:data];
 }
 
 #pragma mark - Property getter / setters

--- a/ios/sdk/src/JitsiMeetViewDelegate.h
+++ b/ios/sdk/src/JitsiMeetViewDelegate.h
@@ -69,4 +69,11 @@
 */
 - (void)openParticipants:(NSDictionary *)data;
 
+/**
+* Called when there is any change in the current participants list.
+*
+* The `data` dictionary contains the updated `participants` list.
+*/
+- (void)participantsChanged:(NSDictionary *)data;
+
 @end

--- a/react/features/mobile/external-api/middleware.js
+++ b/react/features/mobile/external-api/middleware.js
@@ -23,13 +23,21 @@ import { ENTER_PICTURE_IN_PICTURE } from '../picture-in-picture';
 
 import { sendEvent } from './functions';
 import { OPEN_CHAT } from '../../chat';
-import { OPEN_PARTICIPANTS } from '../../base/participants';
+import { OPEN_PARTICIPANTS, PARTICIPANT_JOINED, PARTICIPANT_LEFT, getParticipants, isParticipantModerator } from '../../base/participants';
+import { getTrackByMediaTypeAndParticipant, TRACK_UPDATED } from '../../base/tracks';
+import { MEDIA_TYPE } from '../../base/media';
 
 /**
  * Event which will be emitted on the native side to indicate the conference
  * has ended either by user request or because an error was produced.
  */
 const CONFERENCE_TERMINATED = 'CONFERENCE_TERMINATED';
+
+/**
+ * Event which will be emitted on the native side to indicate that list of participants
+ * has changed.
+ */
+const PARTICIPANTS_CHANGED = 'PARTICIPANTS_CHANGED';
 
 /**
  * Middleware that captures Redux actions and uses the ExternalAPI module to
@@ -43,6 +51,27 @@ MiddlewareRegistry.register(store => next => action => {
     const { type } = action;
 
     switch (type) {
+    case PARTICIPANT_JOINED:
+    case PARTICIPANT_LEFT:
+    case TRACK_UPDATED:
+        const state = store.getState()
+        const jitsiParticipants = getParticipants(state)
+        const tracks = state['features/base/tracks'];
+        const participants = jitsiParticipants.map(p => {
+            const audioTrack = getTrackByMediaTypeAndParticipant(tracks, MEDIA_TYPE.AUDIO, p.id)
+            const videoTrack = getTrackByMediaTypeAndParticipant(tracks, MEDIA_TYPE.VIDEO, p.id)
+            return {
+                id: p.id,
+                name: p.name,
+                avatarURL: p.avatarURL,
+                isLocal: p.local,
+                isModerator: isParticipantModerator(p),
+                audioMuted: audioTrack?.muted ?? true,
+                videoMuted: !videoTrack || videoTrack.muted
+            }
+        })
+        sendEvent(store, PARTICIPANTS_CHANGED, { participants: JSON.stringify(participants) })
+        break;
     case OPEN_CHAT:
         sendEvent(store, OPEN_CHAT, {});
         break;


### PR DESCRIPTION
- fire `PARTICIPANTS_CHANGED` event to native code whenever `PARTICIPANT_JOINED`, `PARTICIPANT_LEFT` or `TRACK_UPDATED` action is fired. The `PARTICIPANTS_CHANGED` event has payload of the current conference participants that are passed as `string` to ease the communication between JS and Java/Objective C.
- expose new `dispatchReduxAction(action)` method to the public `JitsiMeet` interface which sends message to JS code to dispatch a redux action. To implement this communication between native and JS code I extended jitsi's `ExternalAPI` module.
