### PR TITLE
[244] [Jitsi Facelift] Create top left mic and camera indicators

### DIFF
--- a/css/threeveta/_top-bar.scss
+++ b/css/threeveta/_top-bar.scss
@@ -2,6 +2,7 @@
     .subject {
         top: -57px;
         height: 115px;
+        overflow: visible;
         .tvt-conference-timer-wrapper {
             min-height: 25px;
         }
@@ -34,10 +35,30 @@
                 left: 0px;
             }
         }
+        .tvt-status-indicators-wrapper {
+            position: relative;
+            width: fit-content;
+            top: 33px;
+            @include transition(top .3s ease-in);
+            & > div {
+                display: flex;
+                flex-direction: row;
+                justify-content: start;
+                .indicator-container {
+                    margin-right: 4px;
+                    .moderator-icon {
+                        display: none;
+                    }
+                }
+            }
+        }
         &.visible {
             top: 0px;
             .tvt-subject-indicator-watermarks-wrapper {
                 top: 6px;
+            }
+            .tvt-status-indicators-wrapper {
+                top: 7px;
             }
         }
     }

--- a/react/features/conference/components/web/Subject.js
+++ b/react/features/conference/components/web/Subject.js
@@ -108,8 +108,6 @@ function _mapStateToProps(state) {
     const participantCount = getParticipantCount(state);
     const _localParticipant = getLocalParticipant(state);
 
-    console.log('GGP_localParticipant:', _localParticipant);
-
     return {
         _showParticipantCount: participantCount > 2,
         _subject: getConferenceName(state),

--- a/react/features/conference/components/web/Subject.js
+++ b/react/features/conference/components/web/Subject.js
@@ -2,8 +2,9 @@
 
 import React, { Component } from 'react';
 
+import { StatusIndicators } from '../../../../../react/features/filmstrip';
 import { getConferenceName } from '../../../base/conference/functions';
-import { getParticipantCount } from '../../../base/participants/functions';
+import { getLocalParticipant, getParticipantCount } from '../../../base/participants/functions';
 import Watermarks from '../../../base/react/components/web/Watermarks';
 import { connect } from '../../../base/redux';
 import { TvtConnectionIndicator } from '../../../connection-indicator/components/web';
@@ -33,7 +34,12 @@ type Props = {
     /**
      * Indicates whether the component should be visible or not.
      */
-    _visible: boolean
+    _visible: boolean,
+
+    /**
+     * The local participant.
+     */
+    _localParticipant: Object
 };
 
 /**
@@ -50,7 +56,7 @@ class Subject extends Component<Props> {
      * @returns {ReactElement}
      */
     render() {
-        const { _showParticipantCount, _subject, _visible } = this.props;
+        const { _localParticipant, _showParticipantCount, _subject, _visible } = this.props;
 
         return (
             <div className = { `subject ${_visible ? 'visible' : ''}` }>
@@ -76,6 +82,12 @@ class Subject extends Component<Props> {
                         showLogs = { true } />
                     <Watermarks />
                 </div>
+
+                {!interfaceConfig.MEETING_IS_WAITING_ROOM
+                && <div className = 'tvt-status-indicators-wrapper'>
+                    <StatusIndicators
+                        participantID = { _localParticipant.id } />
+                </div>}
             </div>
         );
     }
@@ -94,11 +106,15 @@ class Subject extends Component<Props> {
  */
 function _mapStateToProps(state) {
     const participantCount = getParticipantCount(state);
+    const _localParticipant = getLocalParticipant(state);
+
+    console.log('GGP_localParticipant:', _localParticipant);
 
     return {
         _showParticipantCount: participantCount > 2,
         _subject: getConferenceName(state),
-        _visible: isToolboxVisible(state) && participantCount > 1
+        _visible: isToolboxVisible(state) && participantCount > 1,
+        _localParticipant
     };
 }
 


### PR DESCRIPTION
## [Trello Card](https://trello.com/c/YbrzcGNJ/244-jitsi-facelift-create-top-left-mic-and-camera-indicators)

## Description
In this PR we are adding audio and video muted indicators to the Jitsi-Meeting top bar.

![Selection_011](https://user-images.githubusercontent.com/5963367/102607495-1109f400-4131-11eb-8feb-ddbb862783f0.png)
![Selection_012](https://user-images.githubusercontent.com/5963367/102607496-11a28a80-4131-11eb-8e4b-e0438ad0a0dd.png)
