### PR TITLE
200 facelift mobile app to look like the web

### DIFF
--- a/react/features/large-video/components/LargeVideo.native.js
+++ b/react/features/large-video/components/LargeVideo.native.js
@@ -1,15 +1,14 @@
 // @flow
 
 import React, { PureComponent } from 'react';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import { ColorSchemeRegistry } from '../../base/color-scheme';
-import { ParticipantView, getParticipantById, isParticipantModerator } from '../../base/participants';
+import { ParticipantView, getParticipantById } from '../../base/participants';
 import { connect } from '../../base/redux';
 import { StyleType } from '../../base/styles';
 import { isLocalVideoTrackDesktop } from '../../base/tracks/functions';
 
 import styles, { AVATAR_SIZE } from './styles';
-import { getFeatureFlag, ALWAYS_PIN_MODERATOR_ENABLED } from '../../base/flags';
 
 /**
  * The type of the React {@link Component} props of {@link LargeVideo}.
@@ -122,7 +121,6 @@ class LargeVideo extends PureComponent<Props, State> {
             _disableVideo,
             _participantId,
             _styles,
-            _waitingForModerator,
             onClick
         } = this.props;
 
@@ -138,12 +136,6 @@ class LargeVideo extends PureComponent<Props, State> {
                     useConnectivityInfoLabel = { useConnectivityInfoLabel }
                     zOrder = { 0 }
                     zoomEnabled = { true } />
-                {_waitingForModerator && (
-                    <View style={styles.waitingMessageContainer}>
-                        {/* TODO translate */}
-                        <Text style={styles.waitingMessageText}>Waiting for meeting host...</Text>
-                    </View>
-                )}
             </View>
         );
     }
@@ -159,7 +151,6 @@ class LargeVideo extends PureComponent<Props, State> {
 function _mapStateToProps(state) {
     const { participantId } = state['features/large-video'];
     const participant = getParticipantById(state, participantId);
-    const alwaysPinModerator = getFeatureFlag(state, ALWAYS_PIN_MODERATOR_ENABLED, false);
     const { clientHeight: height, clientWidth: width } = state['features/base/responsive-ui'];
     let disableVideo = false;
 
@@ -173,7 +164,6 @@ function _mapStateToProps(state) {
         _participantId: participantId,
         _styles: ColorSchemeRegistry.get(state, 'LargeVideo'),
         _width: width,
-        _waitingForModerator: alwaysPinModerator && !isParticipantModerator(participant),
     };
 }
 

--- a/react/features/large-video/components/styles.js
+++ b/react/features/large-video/components/styles.js
@@ -13,23 +13,6 @@ export default {
         alignItems: "center",
         justifyContent: "center",
     },
-    waitingMessageContainer: {
-        position: "absolute",
-        padding: 15,
-        backgroundColor: "#FF6926",
-        borderRadius: 5,
-        shadowColor: "#000",
-        shadowOffset: {
-            width: 0,
-            height: 2,
-        },
-        shadowOpacity: 0.25,
-        shadowRadius: 3.84,
-        elevation: 5,
-    },
-    waitingMessageText: {
-        color: 'white',
-    },
 };
 
 /**

--- a/react/features/welcome/components/WelcomePage.native.js
+++ b/react/features/welcome/components/WelcomePage.native.js
@@ -34,6 +34,7 @@ import {
     _mapStateToProps as _abstractMapStateToProps,
 } from "./AbstractWelcomePage";
 import styles from "./styles";
+import { ColorSchemeRegistry } from "../../base/color-scheme";
 
 const { AudioMode } = NativeModules;
 
@@ -173,7 +174,7 @@ class WelcomePage extends AbstractWelcomePage {
                         style={styles.spekaersSelector}
                     >
                         <Text style={{ flex: 1 }}>{selectedDevice?.text}</Text>
-                        <Icon src={IconArrowDown} size={16} color="#923BBA" />
+                        <Icon src={IconArrowDown} size={16} color={this.props._iconColor} />
                     </TouchableOpacity>
                     <View style={styles.speakersDropDown}>
                         <Collapsible
@@ -189,7 +190,7 @@ class WelcomePage extends AbstractWelcomePage {
 
     _renderDevice(device) {
         const { icon, selected, text } = device;
-        const selectedStyle = selected ? styles.selectedText : {};
+        const selectedStyle = selected ? { color: this.props._iconColor } : {};
 
         return (
             <TouchableHighlight
@@ -250,6 +251,7 @@ function _mapStateToProps(state) {
         ..._abstractMapStateToProps(state),
         _localVideoTrack: getLocalVideoTrack(state["features/base/tracks"]),
         _devices: state["features/mobile/audio-mode"].devices,
+        _iconColor: ColorSchemeRegistry._getColor(state, '', 'icon'),
         // _reducedUI: state['features/base/responsive-ui'].reducedUI
     };
 }

--- a/react/features/welcome/components/styles.js
+++ b/react/features/welcome/components/styles.js
@@ -366,7 +366,7 @@ export default {
     localVideTrackContainer: {
         width: "100%",
         height: 300,
-        borderRadius: 15,
+        borderRadius: 10,
         overflow: "hidden",
     },
 
@@ -381,7 +381,7 @@ export default {
         width: "100%",
         height: 50,
         backgroundColor: "#F4F5FA",
-        borderRadius: 8,
+        borderRadius: 5,
         alignItems: "center",
         flexDirection: "row",
         paddingHorizontal: 15,


### PR DESCRIPTION
[Trello card](https://trello.com/c/9G7b9DG7/200-facelift-mobile-app-to-look-like-the-web)

- remove waiting for host message as we now show it in our threeveta code
- make selected sound device to be displayed in the `icon` schemed color that we pass from our app
- other small style changes in the welcome screen that we use for waiting room
