### PR TITLE
[296] Hide jitsi before and after meeting pages

### DIFF
--- a/react/features/feedback/actions.js
+++ b/react/features/feedback/actions.js
@@ -104,10 +104,15 @@ export function maybeOpenFeedbackDialog(conference: Object) {
  * @returns {Object}
  */
 export function openFeedbackDialog(conference: Object, onClose: ?Function) {
-    return openDialog(FeedbackDialog, {
-        conference,
-        onClose
-    });
+    // Threeveta removed functionality.
+    // In order to not show the jitsi FeedbackDialog we are not executing the
+    // open dialog function.
+    return;
+
+    // return openDialog(FeedbackDialog, {
+    //     conference,
+    //     onClose
+    // });
 }
 
 /**

--- a/react/features/welcome/functions.js
+++ b/react/features/welcome/functions.js
@@ -41,8 +41,12 @@ export function isWelcomePageAppEnabled(stateful: Function | Object) {
  * {@code true}; otherwise, {@code false}.
  */
 export function isWelcomePageUserEnabled(stateful: Function | Object) {
-    return (
-        typeof APP === 'undefined'
-            ? true
-            : toState(stateful)['features/base/config'].enableWelcomePage);
+    // Threeveta added logic.
+    // We want the wellcome page to be allways disabled.
+    return false;
+
+    // return (
+    //     typeof APP === 'undefined'
+    //         ? true
+    //         : toState(stateful)['features/base/config'].enableWelcomePage);
 }


### PR DESCRIPTION
## [Trello Card](https://trello.com/c/czkrAX2A/296-hide-jitsi-before-and-after-meeting-pages)

## Description
In this PR we are hiding the Wellcome page and the jitsi feedback dialog.
![WellcomeScreenAndFeedbackDialog](https://user-images.githubusercontent.com/5963367/103218690-6cec2e00-4924-11eb-92c2-e4f65d525acb.gif)

## Changes
- Adds always `false` result of the isWelcomePageUserEnabled in order to
  not show the welcome page
- Comments the logic for the opening of the `FeedbackDialog`