### PR TITLE
281 show indication that there are new chat messages

### DIFF
--- a/ios/sdk/src/ExternalAPI.m
+++ b/ios/sdk/src/ExternalAPI.m
@@ -34,6 +34,10 @@ RCT_EXPORT_MODULE();
     };
 };
 
+- (NSArray<NSString *> *)supportedEvents {
+    return @[DISPATCH_REDUX_ACTION];
+}
+
 /**
  * Dispatches an event that occurred on JavaScript to the view's delegate.
  *

--- a/react/features/chat/actionTypes.js
+++ b/react/features/chat/actionTypes.js
@@ -57,3 +57,13 @@ export const SET_PRIVATE_MESSAGE_RECIPIENT = 'SET_PRIVATE_MESSAGE_RECIPIENT';
 export const TOGGLE_CHAT = 'TOGGLE_CHAT';
 
 export const OPEN_CHAT = 'OPEN_CHAT';
+
+/**
+ * The type of action to set the unread chat messages count. (dispatched from Threeveta code)
+ *
+ * {
+ *     type: SET_UNREAD_MESSAGES_COUNT
+ *     unreadMessagesCount: number
+ * }
+ */
+export const SET_UNREAD_MESSAGES_COUNT = 'SET_UNREAD_MESSAGES_COUNT';

--- a/react/features/chat/components/native/ChatButton.js
+++ b/react/features/chat/components/native/ChatButton.js
@@ -1,5 +1,5 @@
 // @flow
-
+import React from 'react'
 import { CHAT_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { IconChat, IconChatUnread } from '../../../base/icons';
 import { setActiveModalId } from '../../../base/modal';
@@ -9,10 +9,15 @@ import {
     AbstractButton,
     type AbstractButtonProps
 } from '../../../base/toolbox/components';
+import { ColorSchemeRegistry } from '../../../base/color-scheme';
+import ToolboxItem from '../../../base/toolbox/components/ToolboxItem'
 import { openDisplayNamePrompt } from '../../../display-name';
 import { CHAT_VIEW_MODAL_ID } from '../../constants';
 import { getUnreadCount } from '../../functions';
 import { openChat } from '../../actions.any';
+import { View, Text } from 'react-native';
+
+import styles from './styles';
 
 type Props = AbstractButtonProps & {
 
@@ -72,8 +77,40 @@ class ChatButton extends AbstractButton<Props, *> {
      * @protected
      * @returns {boolean}
      */
-    _isToggled() {
-        return Boolean(this.props._unreadMessageCount);
+    // _isToggled() {
+    //     return Boolean(this.props._unreadMessageCount);
+    // }
+
+    render(): React$Node {
+        const props = {
+            ...this.props,
+            accessibilityLabel: this.accessibilityLabel,
+            disabled: this._isDisabled(),
+            elementAfter: this._getElementAfter(),
+            icon: this._getIcon(),
+            label: this._getLabel(),
+            styles: this._getStyles(),
+            toggled: this._isToggled(),
+            tooltip: this._getTooltip()
+        };
+
+        const { _unreadMessageCount } = this.props
+
+        return (
+            <View>
+                <ToolboxItem
+                    disabled = { this._isDisabled() }
+                    onClick = { this._onClick }
+                    { ...props } />
+                {_unreadMessageCount > 0 && (
+                    <View style={this.props._styles.unreadIndicatorContainer}>
+                        <Text style={styles.unreadText}>
+                            {_unreadMessageCount > 9 ? '9+' : _unreadMessageCount}
+                        </Text>
+                    </View>
+                )}
+            </View>
+        );
     }
 }
 
@@ -137,7 +174,8 @@ function _mapStateToProps(state, ownProps) {
     return {
         _showNamePrompt: !localParticipant.name,
         _unreadMessageCount: getUnreadCount(state),
-        visible
+        visible,
+        _styles: ColorSchemeRegistry.get(state, 'Chat')
     };
 }
 

--- a/react/features/chat/components/native/styles.js
+++ b/react/features/chat/components/native/styles.js
@@ -124,6 +124,11 @@ export default {
     timeText: {
         color: 'rgb(164, 184, 209)',
         fontSize: 13
+    },
+
+    unreadText: {
+        color: 'white',
+        fontWeight: 'bold'
     }
 };
 
@@ -199,5 +204,17 @@ ColorSchemeRegistry.register('Chat', {
             fontSize: 22,
             padding: 8
         }
+    },
+
+    unreadIndicatorContainer: {
+        position: 'absolute', 
+        bottom: -5, 
+        right: -3, 
+        width: 25, 
+        height: 25, 
+        borderRadius: 13, 
+        backgroundColor: schemeColor('unreadIndicatorBackground'), 
+        alignItems: 'center', 
+        justifyContent: 'center',
     }
 });

--- a/react/features/chat/functions.js
+++ b/react/features/chat/functions.js
@@ -62,19 +62,21 @@ export function replaceNonUnicodeEmojis(message: string) {
  * @returns {number} The number of unread messages.
  */
 export function getUnreadCount(state: Object) {
-    const { lastReadMessage, messages } = state['features/chat'];
-    const messagesCount = messages.length;
+    // const { lastReadMessage, messages } = state['features/chat'];
+    // const messagesCount = messages.length;
 
-    if (!messagesCount) {
-        return 0;
-    }
+    // if (!messagesCount) {
+    //     return 0;
+    // }
 
-    if (navigator.product === 'ReactNative') {
-        // React native stores the messages in a reversed order.
-        return messages.indexOf(lastReadMessage);
-    }
+    // if (navigator.product === 'ReactNative') {
+    //     // React native stores the messages in a reversed order.
+    //     return messages.indexOf(lastReadMessage);
+    // }
 
-    const lastReadIndex = messages.lastIndexOf(lastReadMessage);
+    // const lastReadIndex = messages.lastIndexOf(lastReadMessage);
 
-    return messagesCount - (lastReadIndex + 1);
+    // return messagesCount - (lastReadIndex + 1);
+
+    return state['features/chat'].unreadMessagesCount
 }

--- a/react/features/chat/reducer.js
+++ b/react/features/chat/reducer.js
@@ -7,7 +7,8 @@ import {
     ADD_MESSAGE,
     CLEAR_MESSAGES,
     SET_PRIVATE_MESSAGE_RECIPIENT,
-    TOGGLE_CHAT
+    TOGGLE_CHAT,
+    SET_UNREAD_MESSAGES_COUNT
 } from './actionTypes';
 import { CHAT_VIEW_MODAL_ID } from './constants';
 
@@ -15,7 +16,8 @@ const DEFAULT_STATE = {
     isOpen: false,
     lastReadMessage: undefined,
     messages: [],
-    privateMessageRecipient: undefined
+    privateMessageRecipient: undefined,
+    unreadMessagesCount: 0,
 };
 
 ReducerRegistry.register('features/chat', (state = DEFAULT_STATE, action) => {
@@ -73,6 +75,12 @@ ReducerRegistry.register('features/chat', (state = DEFAULT_STATE, action) => {
 
     case TOGGLE_CHAT:
         return updateChatState(state);
+
+    case SET_UNREAD_MESSAGES_COUNT:
+        return {
+            ...state,
+            unreadMessagesCount: action.unreadMessagesCount
+        };
     }
 
     return state;


### PR DESCRIPTION
[Trello card](https://trello.com/c/Ew2A6yY2/281-show-indication-that-there-are-new-chat-messages)

Add unread messages count indicator to the chat toolbar button. 
Store the `unreadMessagesCount` in redux and update it with `SET_UNREAD_MESSAGES_COUNT` action that is dispatched from our threeveta code.