### PR TITLE
[341] [Not billed - Jasen mistake] FIx Jitsi ShareScreen and View Full-Screen letter casing

### DIFF
--- a/css/threeveta/_bottom-controls.scss
+++ b/css/threeveta/_bottom-controls.scss
@@ -28,6 +28,7 @@ $button-padding: 6px;
             padding: $button-padding ($button-padding * 3);
             .tvt-icon-label {
                 margin-left: 1em;
+                text-transform: none;
             }
         }
         @media only screen and (max-width: 700px) {

--- a/lang/main.json
+++ b/lang/main.json
@@ -934,8 +934,8 @@
     "threeveta": {
         "toolbar": {
             "shareScreen": "Share screen",
-            "enterFullScreen": "View Full Screen",
-            "exitFullScreen": "Exit Full Screen"
+            "enterFullScreen": "View full screen",
+            "exitFullScreen": "Exit full screen"
         },
         "videothumbnail": {
             "audioAvailable": "Participant audio is available"


### PR DESCRIPTION
## [Threlo Card](https://trello.com/c/cmIQ8DhD/341-fix-jitsi-sharescreen-and-view-full-screen-letter-casing)

## Description
In this PR we are updating ShareScreen and ViewFullScreen button labels according to the designs.

## Before
![before](https://user-images.githubusercontent.com/5963367/104218737-d5b7c800-5445-11eb-879f-d7da859c37e8.png)

## After
![Selection_001](https://user-images.githubusercontent.com/5963367/104218760-dea89980-5445-11eb-82f1-0f8893545695.png)
