### PR TITLE
386 mobile vertical handling

### DIFF
--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -29,7 +29,8 @@
     }
 }
 #largeVideoBackgroundContainer {
-    filter: blur(40px);
+    filter: blur(20px);
+    opacity: 0.4;
 }
 
 .videocontainer {
@@ -38,7 +39,7 @@
 
     &__background {
         @include topLeft();
-        background-color: black;
+        background-color: #e5e5e56b;
         border-radius: $borderRadius;
         width: 100%;
         height: 100%;

--- a/css/threeveta/_participants.scss
+++ b/css/threeveta/_participants.scss
@@ -228,9 +228,11 @@ $vido-border-radius: 5px;
     #filmstripRemoteVideosContainer {
         .videocontainer {
             overflow: hidden !important;
-            video {
-                object-fit: cover !important;
-            }
+
+            // Vertical video container
+            // video {
+            //     object-fit: cover !important;
+            // }
         }
     }
 }


### PR DESCRIPTION
- Vertical videos are now shown in full height
- Black stripes next to the vertical video are now semi transparent white
- Shared screen backlight is now semi-transparent
- https://github.com/threeveta/jitsi-meet/commit/006a50fa0a4ee34d5ef7483ba882165af7305912