### PR TITLE
391 iphone disconnects me when there is no one in the meeting

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioModeModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioModeModule.java
@@ -393,7 +393,7 @@ class AudioModeModule extends ReactContextBaseJavaModule {
      */
     void resetSelectedDevice() {
         selectedDevice = null;
-        userSelectedDevice = null;
+//        userSelectedDevice = null;
     }
 
     /**

--- a/react/features/welcome/components/WelcomePage.native.js
+++ b/react/features/welcome/components/WelcomePage.native.js
@@ -4,6 +4,7 @@ import {
     TouchableOpacity,
     View,
     NativeModules,
+    Platform,
 } from "react-native";
 import Collapsible from "react-native-collapsible";
 import _ from "lodash";
@@ -35,6 +36,7 @@ import {
 } from "./AbstractWelcomePage";
 import styles from "./styles";
 import { ColorSchemeRegistry } from "../../base/color-scheme";
+import { updateSettings } from "../../base/settings";
 
 const { AudioMode } = NativeModules;
 
@@ -113,6 +115,12 @@ class WelcomePage extends AbstractWelcomePage {
         AudioMode.setMode(AudioMode.VIDEO_CALL).catch((err) =>
             logger.error(`Failed to set audio mode ${String(mode)}: ${err}`)
         );
+
+        // Disable call integration for android, otherwise the output device list is empty,
+        // because we are not yet in a call here
+        if (Platform.OS === 'android') {
+            this.props.dispatch(updateSettings({ disableCallIntegration: true }))
+        }
 
         this._setUpLocalVideoTrack();
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/olMoPwwx/391-iphone-disconnects-me-when-there-is-no-one-in-the-meeting)

- disable Jitsi's call integration in the waiting room for android, because the call integration setting blocks us from retrieving the output device list.
- Keep `userSelectedDevice` in the AudioModule
