### PR TITLE
400 iphone logs meetings through 3veta suboptimally

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioModeModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioModeModule.java
@@ -393,7 +393,7 @@ class AudioModeModule extends ReactContextBaseJavaModule {
      */
     void resetSelectedDevice() {
         selectedDevice = null;
-//        userSelectedDevice = null;
+        userSelectedDevice = null;
     }
 
     /**

--- a/ios/sdk/src/JitsiMeetConferenceOptions.h
+++ b/ios/sdk/src/JitsiMeetConferenceOptions.h
@@ -38,6 +38,8 @@
  */
 @property (nonatomic, copy, nullable) NSString *token;
 
+@property (nonatomic, copy, nullable) NSString *callHandle;
+
 /**
  * Color scheme override, see:
  * https://github.com/jitsi/jitsi-meet/blob/master/react/features/base/color-scheme/defaultScheme.js
@@ -82,6 +84,7 @@
 @property (nonatomic, copy, nullable, readonly) NSString *room;
 @property (nonatomic, copy, nullable, readonly) NSString *subject;
 @property (nonatomic, copy, nullable, readonly) NSString *token;
+@property (nonatomic, copy, nullable, readonly) NSString *callHandle;
 
 @property (nonatomic, copy, nullable) NSDictionary *colorScheme;
 @property (nonatomic, readonly, nonnull) NSDictionary *featureFlags;

--- a/ios/sdk/src/JitsiMeetConferenceOptions.m
+++ b/ios/sdk/src/JitsiMeetConferenceOptions.m
@@ -43,6 +43,7 @@ static NSString *const WelcomePageEnabledFeatureFlag = @"welcomepage.enabled";
         _room = nil;
         _subject = nil;
         _token = nil;
+        _callHandle = nil;
 
         _colorScheme = nil;
         _featureFlags = [[NSMutableDictionary alloc] init];
@@ -160,6 +161,7 @@ static NSString *const WelcomePageEnabledFeatureFlag = @"welcomepage.enabled";
         _room = builder.room;
         _subject = builder.subject;
         _token = builder.token;
+        _callHandle = builder.callHandle;
 
         _colorScheme = builder.colorScheme;
 
@@ -211,6 +213,9 @@ static NSString *const WelcomePageEnabledFeatureFlag = @"welcomepage.enabled";
     }
     if (_language != nil) {
         config[@"language"] = self.language;
+    }
+    if (_callHandle != nil) {
+        config[@"callHandle"] = self.callHandle;
     }
 
     NSMutableDictionary *urlProps = [[NSMutableDictionary alloc] init];

--- a/react/features/welcome/components/WelcomePage.native.js
+++ b/react/features/welcome/components/WelcomePage.native.js
@@ -116,12 +116,6 @@ class WelcomePage extends AbstractWelcomePage {
             logger.error(`Failed to set audio mode ${String(mode)}: ${err}`)
         );
 
-        // Disable call integration for android, otherwise the output device list is empty,
-        // because we are not yet in a call here
-        if (Platform.OS === 'android') {
-            this.props.dispatch(updateSettings({ disableCallIntegration: true }))
-        }
-
         this._setUpLocalVideoTrack();
 
         AudioMode.updateDeviceList && AudioMode.updateDeviceList();


### PR DESCRIPTION
[Trello card](https://trello.com/c/8VVcnyDO/400-iphone-logs-meetings-through-3veta-suboptimally)

- include `callHandle` in ios `JitsiMeetConferenceOptions` which is passed to meeting `config`
- revert previous hacky changes for android call integration. It is disabled for android for now.
