### PR TITLE
446 mobile screen sharing clean

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetOngoingConferenceService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetOngoingConferenceService.java
@@ -43,7 +43,7 @@ public class JitsiMeetOngoingConferenceService extends Service
         static final String HANGUP = TAG + ":HANGUP";
     }
 
-    static void launch(Context context) {
+    public static void launch(Context context) {
         OngoingNotification.createOngoingConferenceNotificationChannel();
 
         Intent intent = new Intent(context, JitsiMeetOngoingConferenceService.class);
@@ -60,7 +60,7 @@ public class JitsiMeetOngoingConferenceService extends Service
         }
     }
 
-    static void abort(Context context) {
+    public static void abort(Context context) {
         Intent intent = new Intent(context, JitsiMeetOngoingConferenceService.class);
         context.stopService(intent);
     }

--- a/react/features/toolbox/components/native/OverflowMenu.js
+++ b/react/features/toolbox/components/native/OverflowMenu.js
@@ -135,7 +135,7 @@ class OverflowMenu extends PureComponent<Props, State> {
                 <AudioOnlyButton { ...buttonProps } />
                 <RaiseHandButton { ...buttonProps } />
                 <LobbyModeButton { ...buttonProps } />
-                {/* <ScreenSharingButton { ...buttonProps } /> */}
+                <ScreenSharingButton { ...buttonProps } />
                 {/* <MoreOptionsButton { ...moreOptionsButtonProps } /> */}
                 {/* <Collapsible collapsed = { !showMore }> */}
                     {/* <ToggleCameraButton { ...buttonProps } /> */}


### PR DESCRIPTION
[Trello card](https://trello.com/c/pcFAFbcn/446-mobile-screen-sharing)

- Show share screen button
- expose `JitsiMeetOngoingConferenceService.launch()` and `JitsiMeetOngoingConferenceService.abort()`, so we can run it from our code.
